### PR TITLE
wallet,waddrmgr: add missing testnet4 cases

### DIFF
--- a/internal/legacy/keystore/keystore_test.go
+++ b/internal/legacy/keystore/keystore_test.go
@@ -984,20 +984,20 @@ func TestImportScript(t *testing.T) {
 	}
 
 	if !bytes.Equal(sinfo.Script(), sinfo2.Script()) {
-		t.Error("original and serailised scriptinfo scripts "+
+		t.Errorf("original and serailised scriptinfo scripts "+
 			"don't match %s != %s", spew.Sdump(sinfo.Script()),
 			spew.Sdump(sinfo2.Script()))
 	}
 
 	if sinfo.ScriptClass() != sinfo2.ScriptClass() {
-		t.Error("original and serailised scriptinfo class "+
+		t.Errorf("original and serailised scriptinfo class "+
 			"don't match: %s != %s", sinfo.ScriptClass(),
 			sinfo2.ScriptClass())
 		return
 	}
 
 	if !reflect.DeepEqual(sinfo.Addresses(), sinfo2.Addresses()) {
-		t.Error("original and serailised scriptinfo addresses "+
+		t.Errorf("original and serailised scriptinfo addresses "+
 			"don't match (%s) != (%s)", spew.Sdump(sinfo.Addresses),
 			spew.Sdump(sinfo2.Addresses()))
 		return

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -2318,7 +2318,7 @@ func (s *ScopedKeyManager) cloneKeyWithVersion(key *hdkeychain.ExtendedKey) (
 			return nil, fmt.Errorf("unsupported scope %v", s.scope)
 		}
 
-	case wire.TestNet, wire.TestNet3,
+	case wire.TestNet, wire.TestNet3, wire.TestNet4,
 		netparams.SigNetWire(s.rootManager.ChainParams()):
 
 		switch s.scope {

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -109,7 +109,7 @@ func (w *Wallet) isPubKeyForNet(pubKey *hdkeychain.ExtendedKey) bool {
 			version == waddrmgr.HDVersionMainNetBIP0049 ||
 			version == waddrmgr.HDVersionMainNetBIP0084
 
-	case wire.TestNet, wire.TestNet3, netparams.SigNetWire(w.chainParams):
+	case wire.TestNet, wire.TestNet3, wire.TestNet4, netparams.SigNetWire(w.chainParams):
 		return version == waddrmgr.HDVersionTestNetBIP0044 ||
 			version == waddrmgr.HDVersionTestNetBIP0049 ||
 			version == waddrmgr.HDVersionTestNetBIP0084


### PR DESCRIPTION
`AccountProperties` does not work on testnet4 because `(*ScopedKeyManager).cloneKeyWithVersion` is missing the `wire.TestNet4` case.  This change works on our app using testnet4.