### PR TITLE
don't panic, retry instead

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -6,7 +6,6 @@ package wallet
 
 import (
 	"bytes"
-	"fmt"
 	"time"
 
 	"github.com/ltcsuite/ltcd/chaincfg/chainhash"
@@ -84,6 +83,42 @@ func (w *Wallet) handleChainNotifications() {
 		return err
 	}
 
+	waitForSync := func(birthdayBlock *waddrmgr.BlockStamp) error {
+		// We start with a retry delay of 0 to execute the first attempt
+		// immediately.
+		var retryDelay time.Duration
+		for {
+			select {
+			case <-time.After(retryDelay):
+				// Set the delay to the configured value in case
+				// we actually need to re-try.
+				retryDelay = w.syncRetryInterval
+
+				// Sync may be interrupted by actions such as
+				// locking the wallet. Try again after waiting a
+				// bit.
+				err = w.syncWithChain(birthdayBlock)
+				if err != nil {
+					if w.ShuttingDown() {
+						return ErrWalletShuttingDown
+					}
+
+					log.Errorf("Unable to synchronize "+
+						"wallet to chain, trying "+
+						"again in %s: %v",
+						w.syncRetryInterval, err)
+
+					continue
+				}
+
+				return nil
+
+			case <-w.quitChan():
+				return ErrWalletShuttingDown
+			}
+		}
+	}
+
 	for {
 		select {
 		case n, ok := <-chainClient.Notifications():
@@ -106,17 +141,23 @@ func (w *Wallet) handleChainNotifications() {
 				birthdayBlock, err := birthdaySanityCheck(
 					chainClient, birthdayStore,
 				)
-				if err != nil && !waddrmgr.IsError(err, waddrmgr.ErrBirthdayBlockNotSet) {
-					panic(fmt.Errorf("unable to sanity "+
-						"check wallet birthday block: %v",
-						err))
+				if err != nil && !waddrmgr.IsError(
+					err, waddrmgr.ErrBirthdayBlockNotSet,
+				) {
+
+					log.Errorf("Unable to sanity check "+
+						"wallet birthday block: %v",
+						err)
 				}
 
-				err = w.syncWithChain(birthdayBlock)
-				if err != nil && !w.ShuttingDown() {
-					panic(fmt.Errorf("unable to synchronize "+
-						"wallet to chain: %v", err))
+				err = waitForSync(birthdayBlock)
+				if err != nil {
+					log.Infof("Stopped waiting for wallet "+
+						"sync due to error: %v", err)
+
+					return
 				}
+
 			case chain.BlockConnected:
 				err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 					return w.connectBlock(tx, wtxmgr.BlockMeta(n))

--- a/wallet/example_test.go
+++ b/wallet/example_test.go
@@ -40,6 +40,7 @@ func testWallet(t *testing.T) (*Wallet, func()) {
 
 	loader := NewLoader(
 		&chaincfg.TestNet4Params, dir, true, defaultDBTimeout, 250,
+		WithWalletSyncRetryInterval(10*time.Millisecond),
 	)
 	w, err := loader.CreateNewWallet(pubPass, privPass, seed, time.Now())
 	if err != nil {
@@ -71,6 +72,7 @@ func testWalletWatchingOnly(t *testing.T) (*Wallet, func()) {
 	pubPass := []byte("hello")
 	loader := NewLoader(
 		&chaincfg.TestNet4Params, dir, true, defaultDBTimeout, 250,
+		WithWalletSyncRetryInterval(10*time.Millisecond),
 	)
 	w, err := loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
 	if err != nil {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -49,6 +49,10 @@ const (
 	// scanned successively by the recovery manager, in the event that the
 	// wallet is started in recovery mode.
 	recoveryBatchSize = 2000
+
+	// defaultSyncRetryInterval is the default amount of time to wait
+	// between re-tries on errors during initial sync.
+	defaultSyncRetryInterval = 5 * time.Second
 )
 
 var (
@@ -143,6 +147,10 @@ type Wallet struct {
 	started bool
 	quit    chan struct{}
 	quitMu  sync.Mutex
+
+	// syncRetryInterval is the amount of time to wait between re-tries on
+	// errors during initial sync.
+	syncRetryInterval time.Duration
 }
 
 // Start starts the goroutines necessary to manage a wallet.
@@ -3817,6 +3825,18 @@ func create(db walletdb.DB, pubPass, privPass []byte,
 func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	params *chaincfg.Params, recoveryWindow uint32) (*Wallet, error) {
 
+	return OpenWithRetry(
+		db, pubPass, cbs, params, recoveryWindow,
+		defaultSyncRetryInterval,
+	)
+}
+
+// OpenWithRetry loads an already-created wallet from the passed database and
+// namespaces and re-tries on errors during initial sync.
+func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
+	params *chaincfg.Params, recoveryWindow uint32,
+	syncRetryInterval time.Duration) (*Wallet, error) {
+
 	var (
 		addrMgr *waddrmgr.Manager
 		txMgr   *wtxmgr.Store
@@ -3881,6 +3901,7 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 		changePassphrases:   make(chan changePassphrasesRequest),
 		chainParams:         params,
 		quit:                make(chan struct{}),
+		syncRetryInterval:   syncRetryInterval,
 	}
 
 	w.NtfnServer = newNotificationServer(w)

--- a/wallet/watchingonly_test.go
+++ b/wallet/watchingonly_test.go
@@ -28,6 +28,7 @@ func TestCreateWatchingOnly(t *testing.T) {
 
 	loader := NewLoader(
 		&chaincfg.TestNet4Params, dir, true, defaultDBTimeout, 250,
+		WithWalletSyncRetryInterval(10*time.Millisecond),
 	)
 	_, err = loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
 	if err != nil {


### PR DESCRIPTION
Taken from btcwallet #870 by @guggero

Fixes a number of overzealous panics that can occur during initial sync and resync.